### PR TITLE
Refactoring: MainPage, TodoList를 중심으로

### DIFF
--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -2,21 +2,14 @@ import React, { ChangeEvent, MouseEvent, useEffect, useState } from 'react';
 import { FC } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Todo } from './TodoList';
-import { TodoServiceImpl } from '../service/todo';
 
 interface TodoItemProps {
   todo: Todo;
   onDeleteTodo: (id: string) => void;
   onUpdateTodo: (id: string, title: string, content: string) => void;
-  todoService: TodoServiceImpl;
 }
 
-const TodoItem: FC<TodoItemProps> = ({
-  todo,
-  onDeleteTodo,
-  onUpdateTodo,
-  todoService,
-}) => {
+const TodoItem: FC<TodoItemProps> = ({ todo, onDeleteTodo, onUpdateTodo }) => {
   const [title, setTitle] = useState<string>(todo.title);
   const [content, setContent] = useState<string>(todo.content);
   const [addable, setAddable] = useState<boolean>(false);

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -35,9 +35,13 @@ const TodoItem: FC<TodoItemProps> = ({ todo, onDeleteTodo, onUpdateTodo }) => {
     }
   };
 
-  const handleCancel = (e: MouseEvent<HTMLButtonElement>) => {
+  function 수정_전_상태로_복구() {
     setTitle(originalTitle);
     setContent(originalContent);
+  }
+
+  const handleCancel = (e: MouseEvent<HTMLButtonElement>) => {
+    수정_전_상태로_복구();
     setAddable(!addable);
   };
 

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -52,8 +52,10 @@ const TodoItem: FC<TodoItemProps> = ({ todo, onDeleteTodo, onUpdateTodo }) => {
 
   const handleUpdate = (e: MouseEvent<HTMLButtonElement>) => {
     if (수정가능) {
+      // 저장 버튼 누를 때
       onUpdateTodo(todo.id, title, content);
     } else {
+      // 수정 버튼 누를 때
       수정_전_상태_저장();
     }
     set수정가능(!수정가능);

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -45,12 +45,16 @@ const TodoItem: FC<TodoItemProps> = ({ todo, onDeleteTodo, onUpdateTodo }) => {
     setAddable(!addable);
   };
 
+  function 수정_전_상태_저장() {
+    setOriginalTitle(title);
+    setOriginalContent(content);
+  }
+
   const handleUpdate = (e: MouseEvent<HTMLButtonElement>) => {
     if (addable) {
       onUpdateTodo(todo.id, title, content);
     } else {
-      setOriginalTitle(title);
-      setOriginalContent(content);
+      수정_전_상태_저장();
     }
     setAddable(!addable);
   };

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -12,7 +12,7 @@ interface TodoItemProps {
 const TodoItem: FC<TodoItemProps> = ({ todo, onDeleteTodo, onUpdateTodo }) => {
   const [title, setTitle] = useState<string>(todo.title);
   const [content, setContent] = useState<string>(todo.content);
-  const [addable, setAddable] = useState<boolean>(false);
+  const [수정가능, set수정가능] = useState<boolean>(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const [originalTitle, setOriginalTitle] = useState<string>('');
   const [originalContent, setOriginalContent] = useState<string>('');
@@ -42,7 +42,7 @@ const TodoItem: FC<TodoItemProps> = ({ todo, onDeleteTodo, onUpdateTodo }) => {
 
   const handleCancel = (e: MouseEvent<HTMLButtonElement>) => {
     수정_전_상태로_복구();
-    setAddable(!addable);
+    set수정가능(!수정가능);
   };
 
   function 수정_전_상태_저장() {
@@ -51,12 +51,12 @@ const TodoItem: FC<TodoItemProps> = ({ todo, onDeleteTodo, onUpdateTodo }) => {
   }
 
   const handleUpdate = (e: MouseEvent<HTMLButtonElement>) => {
-    if (addable) {
+    if (수정가능) {
       onUpdateTodo(todo.id, title, content);
     } else {
       수정_전_상태_저장();
     }
-    setAddable(!addable);
+    set수정가능(!수정가능);
   };
 
   function handleDelete(e: MouseEvent<HTMLButtonElement>) {
@@ -84,17 +84,17 @@ const TodoItem: FC<TodoItemProps> = ({ todo, onDeleteTodo, onUpdateTodo }) => {
         type="text"
         value={title}
         onChange={handleChange}
-        disabled={!addable}
+        disabled={!수정가능}
       />
       <input
         name="content"
         type="text"
         value={content}
         onChange={handleChange}
-        disabled={!addable}
+        disabled={!수정가능}
       />
-      {addable && <button onClick={handleCancel}>취소</button>}
-      <button onClick={handleUpdate}>{addable ? '저장' : '수정'}</button>
+      {수정가능 && <button onClick={handleCancel}>취소</button>}
+      <button onClick={handleUpdate}>{수정가능 ? '저장' : '수정'}</button>
       <button onClick={handleDelete}>삭제</button>
       <button onClick={handleDetail}>상세</button>
       <div>

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -1,7 +1,7 @@
 import React, { ChangeEvent, MouseEvent, useEffect, useState } from 'react';
 import { FC } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Todo } from '../pages/MainPage';
+import { Todo } from './TodoList';
 import { TodoServiceImpl } from '../service/todo';
 
 interface TodoItemProps {

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -7,10 +7,16 @@ import { TodoServiceImpl } from '../service/todo';
 interface TodoItemProps {
   todo: Todo;
   handleDelete: (e: MouseEvent<HTMLButtonElement>) => void;
+  onUpdateTodo: (id: string, title: string, content: string) => void;
   todoService: TodoServiceImpl;
 }
 
-const TodoItem: FC<TodoItemProps> = ({ todo, handleDelete, todoService }) => {
+const TodoItem: FC<TodoItemProps> = ({
+  todo,
+  handleDelete,
+  onUpdateTodo,
+  todoService,
+}) => {
   const [title, setTitle] = useState<string>(todo.title);
   const [content, setContent] = useState<string>(todo.content);
   const [addable, setAddable] = useState<boolean>(false);
@@ -44,7 +50,7 @@ const TodoItem: FC<TodoItemProps> = ({ todo, handleDelete, todoService }) => {
 
   const handleUpdate = (e: MouseEvent<HTMLButtonElement>) => {
     if (addable) {
-      todoService.updateTodo(todo.id, title, content);
+      onUpdateTodo(todo.id, title, content);
     } else {
       setOriginalTitle(title);
       setOriginalContent(content);

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -6,14 +6,14 @@ import { TodoServiceImpl } from '../service/todo';
 
 interface TodoItemProps {
   todo: Todo;
-  handleDelete: (e: MouseEvent<HTMLButtonElement>) => void;
+  onDeleteTodo: (id: string) => void;
   onUpdateTodo: (id: string, title: string, content: string) => void;
   todoService: TodoServiceImpl;
 }
 
 const TodoItem: FC<TodoItemProps> = ({
   todo,
-  handleDelete,
+  onDeleteTodo,
   onUpdateTodo,
   todoService,
 }) => {
@@ -57,6 +57,11 @@ const TodoItem: FC<TodoItemProps> = ({
     }
     setAddable(!addable);
   };
+
+  function handleDelete(e: MouseEvent<HTMLButtonElement>) {
+    const id = e.currentTarget.parentElement?.dataset.id!;
+    onDeleteTodo(id);
+  }
 
   const handleDetail = (e: MouseEvent<HTMLButtonElement>) => {
     let params = searchParams.get('id');

--- a/src/components/TodoItems.tsx
+++ b/src/components/TodoItems.tsx
@@ -5,7 +5,7 @@ import TodoItem from './TodoItem';
 import { Todo } from './TodoList';
 
 interface Props {
-  todoList: Todo[];
+  todos: Todo[];
   onDeleteTodo: (e: MouseEvent<HTMLButtonElement>) => void;
   todoService: TodoServiceImpl;
 }
@@ -14,7 +14,7 @@ const TodoItems: FC<Props> = (props: Props) => {
   return (
     <div className="todoItems">
       <ul>
-        {props.todoList.map((todo) => (
+        {props.todos.map((todo) => (
           <TodoItem
             key={todo.id}
             todo={todo}

--- a/src/components/TodoItems.tsx
+++ b/src/components/TodoItems.tsx
@@ -8,7 +8,6 @@ interface Props {
   todos: Todo[];
   onDeleteTodo: (id: string) => void;
   onUpdateTodo: (id: string, title: string, content: string) => void;
-  todoService: TodoServiceImpl;
 }
 
 const TodoItems: FC<Props> = (props: Props) => {
@@ -19,9 +18,8 @@ const TodoItems: FC<Props> = (props: Props) => {
           <TodoItem
             key={todo.id}
             todo={todo}
-            handleDelete={props.onDeleteTodo}
+            onDeleteTodo={props.onDeleteTodo}
             onUpdateTodo={props.onUpdateTodo}
-            todoService={props.todoService}
           />
         ))}
       </ul>

--- a/src/components/TodoItems.tsx
+++ b/src/components/TodoItems.tsx
@@ -7,6 +7,7 @@ import { Todo } from './TodoList';
 interface Props {
   todos: Todo[];
   onDeleteTodo: (e: MouseEvent<HTMLButtonElement>) => void;
+  onUpdateTodo: (id: string, title: string, content: string) => void;
   todoService: TodoServiceImpl;
 }
 
@@ -19,6 +20,7 @@ const TodoItems: FC<Props> = (props: Props) => {
             key={todo.id}
             todo={todo}
             handleDelete={props.onDeleteTodo}
+            onUpdateTodo={props.onUpdateTodo}
             todoService={props.todoService}
           />
         ))}

--- a/src/components/TodoItems.tsx
+++ b/src/components/TodoItems.tsx
@@ -6,7 +6,7 @@ import { Todo } from './TodoList';
 
 interface Props {
   todos: Todo[];
-  onDeleteTodo: (e: MouseEvent<HTMLButtonElement>) => void;
+  onDeleteTodo: (id: string) => void;
   onUpdateTodo: (id: string, title: string, content: string) => void;
   todoService: TodoServiceImpl;
 }

--- a/src/components/TodoItems.tsx
+++ b/src/components/TodoItems.tsx
@@ -1,0 +1,30 @@
+import React, { MouseEvent } from 'react';
+import { FC } from 'react';
+import { TodoServiceImpl } from '../service/todo';
+import TodoItem from './TodoItem';
+import { Todo } from './TodoList';
+
+interface Props {
+  todoList: Todo[];
+  onDeleteTodo: (e: MouseEvent<HTMLButtonElement>) => void;
+  todoService: TodoServiceImpl;
+}
+
+const TodoItems: FC<Props> = (props: Props) => {
+  return (
+    <div className="todoItems">
+      <ul>
+        {props.todoList.map((todo) => (
+          <TodoItem
+            key={todo.id}
+            todo={todo}
+            handleDelete={props.onDeleteTodo}
+            todoService={props.todoService}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default TodoItems;

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -38,12 +38,17 @@ const TodoList: FC<Props> = (props: Props) => {
     });
   }
 
+  function handleUpdateTodo(id: string, title: string, content: string) {
+    props.todoService.updateTodo(id, title, content);
+  }
+
   return (
     <div className="todoList">
       <TodoListHeader onCreateTodo={handleCreateTodo} />
       <TodoItems
         todos={todos}
         onDeleteTodo={handleDeleteTodo}
+        onUpdateTodo={handleUpdateTodo}
         todoService={props.todoService}
       />
     </div>

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -48,7 +48,6 @@ const TodoList: FC<Props> = (props: Props) => {
         todos={todos}
         onDeleteTodo={handleDeleteTodo}
         onUpdateTodo={handleUpdateTodo}
-        todoService={props.todoService}
       />
     </div>
   );

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -1,0 +1,59 @@
+import React, { MouseEvent, useEffect, useState } from 'react';
+import { FC } from 'react';
+import { TodoServiceImpl } from '../service/todo';
+import TodoItem from './TodoItem';
+import TodoListHeader from './TodoListHeader';
+
+interface Props {
+  todoService: TodoServiceImpl;
+}
+
+export interface Todo {
+  title: string;
+  content: string;
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const TodoList: FC<Props> = (props: Props) => {
+  const [todoList, setTodoList] = useState<Todo[]>([]);
+  useEffect(() => {
+    props.todoService.getTodos().then((response) => {
+      setTodoList(response.data);
+    });
+  }, [props.todoService]);
+
+  const handleDeleteTodo = (e: MouseEvent<HTMLButtonElement>) => {
+    const id = e.currentTarget.parentElement?.dataset.id!;
+    props.todoService.deleteTodo(id).then((response) => {
+      setTodoList((todos) => todos.filter((todo) => todo.id !== id));
+    });
+  };
+
+  function handleCreateTodo(title: string, content: string) {
+    props.todoService.createTodo(title, content).then((response) => {
+      setTodoList([...todoList, response.data]);
+    });
+  }
+
+  return (
+    <div className="todoList">
+      <TodoListHeader onCreateTodo={handleCreateTodo} />
+      <div className="todoItems">
+        <ul>
+          {todoList.map((todo) => (
+            <TodoItem
+              key={todo.id}
+              todo={todo}
+              handleDelete={handleDeleteTodo}
+              todoService={props.todoService}
+            />
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default TodoList;

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -2,6 +2,7 @@ import React, { MouseEvent, useEffect, useState } from 'react';
 import { FC } from 'react';
 import { TodoServiceImpl } from '../service/todo';
 import TodoItem from './TodoItem';
+import TodoItems from './TodoItems';
 import TodoListHeader from './TodoListHeader';
 
 interface Props {
@@ -40,18 +41,11 @@ const TodoList: FC<Props> = (props: Props) => {
   return (
     <div className="todoList">
       <TodoListHeader onCreateTodo={handleCreateTodo} />
-      <div className="todoItems">
-        <ul>
-          {todoList.map((todo) => (
-            <TodoItem
-              key={todo.id}
-              todo={todo}
-              handleDelete={handleDeleteTodo}
-              todoService={props.todoService}
-            />
-          ))}
-        </ul>
-      </div>
+      <TodoItems
+        todoList={todoList}
+        onDeleteTodo={handleDeleteTodo}
+        todoService={props.todoService}
+      />
     </div>
   );
 };

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -18,23 +18,23 @@ export interface Todo {
 }
 
 const TodoList: FC<Props> = (props: Props) => {
-  const [todoList, setTodoList] = useState<Todo[]>([]);
+  const [todos, setTodos] = useState<Todo[]>([]);
   useEffect(() => {
     props.todoService.getTodos().then((response) => {
-      setTodoList(response.data);
+      setTodos(response.data);
     });
   }, [props.todoService]);
 
   const handleDeleteTodo = (e: MouseEvent<HTMLButtonElement>) => {
     const id = e.currentTarget.parentElement?.dataset.id!;
     props.todoService.deleteTodo(id).then((response) => {
-      setTodoList((todos) => todos.filter((todo) => todo.id !== id));
+      setTodos((todos) => todos.filter((todo) => todo.id !== id));
     });
   };
 
   function handleCreateTodo(title: string, content: string) {
     props.todoService.createTodo(title, content).then((response) => {
-      setTodoList([...todoList, response.data]);
+      setTodos([...todos, response.data]);
     });
   }
 
@@ -42,7 +42,7 @@ const TodoList: FC<Props> = (props: Props) => {
     <div className="todoList">
       <TodoListHeader onCreateTodo={handleCreateTodo} />
       <TodoItems
-        todoList={todoList}
+        todos={todos}
         onDeleteTodo={handleDeleteTodo}
         todoService={props.todoService}
       />

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -25,8 +25,7 @@ const TodoList: FC<Props> = (props: Props) => {
     });
   }, [props.todoService]);
 
-  const handleDeleteTodo = (e: MouseEvent<HTMLButtonElement>) => {
-    const id = e.currentTarget.parentElement?.dataset.id!;
+  const handleDeleteTodo = (id: string) => {
     props.todoService.deleteTodo(id).then((response) => {
       setTodos((todos) => todos.filter((todo) => todo.id !== id));
     });

--- a/src/components/TodoListHeader.tsx
+++ b/src/components/TodoListHeader.tsx
@@ -1,0 +1,55 @@
+import React, { ChangeEvent, MouseEvent, useState } from 'react';
+import { FC } from 'react';
+
+interface Props {
+  onCreateTodo: (title: string, content: string) => void;
+}
+
+const TodoListHeader: FC<Props> = (props) => {
+  const [title, setTitle] = useState<string>('');
+  const [content, setContent] = useState<string>('');
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const target = e.currentTarget.name;
+    const value = e.currentTarget.value;
+    switch (target) {
+      case 'title':
+        return setTitle(value);
+      case 'content':
+        return setContent(value);
+      default:
+        return;
+    }
+  };
+
+  function clearInputs() {
+    setTitle('');
+    setContent('');
+  }
+  async function handleAdd() {
+    props.onCreateTodo(title, content);
+    clearInputs();
+  }
+
+  return (
+    <div className="todoListHeader">
+      <input
+        name="title"
+        type="text"
+        value={title}
+        onChange={handleChange}
+        placeholder="제목"
+      />
+      <input
+        name="content"
+        type="text"
+        value={content}
+        onChange={handleChange}
+        placeholder="내용"
+      />
+      <button onClick={handleAdd}>추가</button>
+    </div>
+  );
+};
+
+export default TodoListHeader;

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,55 +1,16 @@
-import { ChangeEvent, FC, MouseEvent, useEffect, useState } from 'react';
-import TodoItem from '../components/TodoItem';
+import { FC } from 'react';
+import TodoList from '../components/TodoList';
+
 import TodoListHeader from '../components/TodoListHeader';
 import { TodoServiceImpl } from '../service/todo';
 
 interface MainPageProps {
   todoService: TodoServiceImpl;
 }
-export interface Todo {
-  title: string;
-  content: string;
-  id: string;
-  createdAt: string;
-  updatedAt: string;
-}
 const MainPage: FC<MainPageProps> = ({ todoService }) => {
-  const [todoList, setTodoList] = useState<Todo[]>([]);
-
-  useEffect(() => {
-    todoService.getTodos().then((response) => {
-      setTodoList(response.data);
-    });
-  }, [todoService]);
-
-  const handleDelete = (e: MouseEvent<HTMLButtonElement>) => {
-    const id = e.currentTarget.parentElement?.dataset.id!;
-    todoService.deleteTodo(id).then((response) => {
-      setTodoList((todos) => todos.filter((todo) => todo.id !== id));
-    });
-  };
-
-  function handleCreateTodo(title: string, content: string) {
-    todoService.createTodo(title, content).then((response) => {
-      setTodoList([...todoList, response.data]);
-    });
-  }
-
   return (
     <>
-      <TodoListHeader onCreateTodo={handleCreateTodo} />
-      <div className="lists">
-        <ul>
-          {todoList.map((todo) => (
-            <TodoItem
-              key={todo.id}
-              todo={todo}
-              handleDelete={handleDelete}
-              todoService={todoService}
-            />
-          ))}
-        </ul>
-      </div>
+      <TodoList todoService={todoService} />
     </>
   );
 };

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent, FC, MouseEvent, useEffect, useState } from 'react';
 import TodoItem from '../components/TodoItem';
+import TodoListHeader from '../components/TodoListHeader';
 import { TodoServiceImpl } from '../service/todo';
 
 interface MainPageProps {
@@ -14,35 +15,12 @@ export interface Todo {
 }
 const MainPage: FC<MainPageProps> = ({ todoService }) => {
   const [todoList, setTodoList] = useState<Todo[]>([]);
-  const [title, setTitle] = useState<string>('');
-  const [content, setContent] = useState<string>('');
 
   useEffect(() => {
     todoService.getTodos().then((response) => {
       setTodoList(response.data);
     });
   }, [todoService]);
-
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const target = e.currentTarget.name;
-    const value = e.currentTarget.value;
-    switch (target) {
-      case 'title':
-        return setTitle(value);
-      case 'content':
-        return setContent(value);
-      default:
-        return;
-    }
-  };
-
-  const handleAdd = (e: MouseEvent<HTMLButtonElement>) => {
-    todoService.createTodo(title, content).then((response) => {
-      setTodoList([...todoList, response.data]);
-      setTitle('');
-      setContent('');
-    });
-  };
 
   const handleDelete = (e: MouseEvent<HTMLButtonElement>) => {
     const id = e.currentTarget.parentElement?.dataset.id!;
@@ -51,25 +29,15 @@ const MainPage: FC<MainPageProps> = ({ todoService }) => {
     });
   };
 
+  function handleCreateTodo(title: string, content: string) {
+    todoService.createTodo(title, content).then((response) => {
+      setTodoList([...todoList, response.data]);
+    });
+  }
+
   return (
     <>
-      <div className="add">
-        <input
-          name="title"
-          type="text"
-          value={title}
-          onChange={handleChange}
-          placeholder="제목"
-        />
-        <input
-          name="content"
-          type="text"
-          value={content}
-          onChange={handleChange}
-          placeholder="내용"
-        />
-        <button onClick={handleAdd}>추가</button>
-      </div>
+      <TodoListHeader onCreateTodo={handleCreateTodo} />
       <div className="lists">
         <ul>
           {todoList.map((todo) => (


### PR DESCRIPTION
1. `TodoItem`에 뭉쳐있던 코드 덩어리들 분리
`TodoList`, `TodoListHeader`, `TodoItems`, `TodoItem`으로 분리
2. 컴포넌트 명과 겹치는 state명 수정
`todoList` -> `todos`
3. TodoItem 함수 분리
handler 함수 내부를 `declarative`하게 수정
4. 영문으로 짓기 곤란한 함수명과 state를 한글로 선언